### PR TITLE
Display claim 'n' stake in mobile header

### DIFF
--- a/src/ui/layout/Header.js
+++ b/src/ui/layout/Header.js
@@ -15,6 +15,8 @@ const Header = () => {
     const menu_items = [
         "overview",
         "acquire",
+        "claim",
+        "stake",
         "trade",
         "stats",
         "whitepaper"


### PR DESCRIPTION
-- puts claim and stake back into mobile header because mobile wallets have in app browser capable to interact with web3 apps